### PR TITLE
PIZ1 pizza sizes now correctly listed

### DIFF
--- a/app/services/size.py
+++ b/app/services/size.py
@@ -28,3 +28,10 @@ def get_size_by_id(_id: int):
     response = size if not error else {'error': error}
     status_code = 200 if size else 404 if not error else 400
     return jsonify(response), status_code
+
+@size.route('/', methods=GET)
+def get_ingredients():
+    size, error = SizeController.get_all()
+    response = size if not error else {'error': error}
+    status_code = 200 if size else 404 if not error else 400
+    return jsonify(response), status_code


### PR DESCRIPTION
🤔 **Why?**

- Pizza sizes weren't listed while creating an order, making it impossible to create an order

🛠 **What I changed:**

- Added a route that handles a GET request for the `/size/` endpoint

🗃️ Trello Issues:

- [PIZ1 - I can't create an order (Bug)](https://trello.com/c/8tJkhERE)

🚦 Functional Testing Results:

- No test was broken with this update (This test was previously failing)
![image](https://github.com/user-attachments/assets/522f8e0c-09d8-4fa8-b72e-146a34113946)
